### PR TITLE
Default Totems for all non-base races

### DIFF
--- a/data/sql/db-world/arac.sql
+++ b/data/sql/db-world/arac.sql
@@ -7812,3 +7812,59 @@ UPDATE `quest_template` INNER JOIN `quest_template_addon`
 UPDATE `playercreateinfo_skills`
 	SET `raceMask` = 0
 		WHERE `skill` IN (45, 46, 160, 173, 226) AND `classMask` != 0;
+
+
+-- Alliance default totems is the Dwarf ones
+SET @HumanFireTotem := 30753;
+SET @HumanEarthTotem := 30754;
+SET @HumanWaterTotem := 30755;
+SET @HumanAirTotem := 30736;
+
+SET @NightElfFireTotem := 30753;
+SET @NightElfEarthTotem := 30754;
+SET @NightElfWaterTotem := 30755;
+SET @NightElfAirTotem := 30736;
+
+SET @GnomeFireTotem := 30753;
+SET @GnomeEarthTotem := 30754;
+SET @GnomeWaterTotem := 30755;
+SET @GnomeAirTotem := 30736;
+
+-- Horde default totems is the Orc ones.
+SET @UndeadFireTotem := 30757;
+SET @UndeadEarthTotem := 30758;
+SET @UndeadWaterTotem := 30759;
+SET @UndeadAirTotem := 30756;
+
+SET @BloodElfFireTotem := 30757;
+SET @BloodElfEarthTotem := 30758;
+SET @BloodElfWaterTotem := 30759;
+SET @BloodElfAirTotem := 30756;
+
+-- Human, Night Elf, Undead, Gnome and Blood Elf
+DELETE FROM player_totem_model WHERE RaceID IN (1,4,5,7,10);
+INSERT INTO player_totem_model (TotemID, RaceID, ModelID) VALUES 
+(1, 1, @HumanFireTotem),
+(2, 1, @HumanEarthTotem),
+(3, 1, @HumanWaterTotem),
+(4, 1, @HumanAirTotem),
+
+(1, 4, @NightElfFireTotem),
+(2, 4, @NightElfEarthTotem),
+(3, 4, @NightElfWaterTotem),
+(4, 4, @NightElfAirTotem),
+
+(1, 5, @UndeadFireTotem),
+(2, 5, @UndeadEarthTotem),
+(3, 5, @UndeadWaterTotem),
+(4, 5, @UndeadAirTotem),
+
+(1, 7, @GnomeFireTotem),
+(2, 7, @GnomeEarthTotem),
+(3, 7, @GnomeWaterTotem),
+(4, 7, @GnomeAirTotem),
+
+(1, 10, @BloodElfFireTotem),
+(2, 10, @BloodElfEarthTotem),
+(3, 10, @BloodElfWaterTotem),
+(4, 10, @BloodElfAirTotem);

--- a/data/sql/db-world/arac.sql
+++ b/data/sql/db-world/arac.sql
@@ -7815,29 +7815,29 @@ UPDATE `playercreateinfo_skills`
 
 
 -- Alliance default totems is the Dwarf ones
-SET @HumanFireTotem := 30753;
-SET @HumanEarthTotem := 30754;
+SET @HumanFireTotem := 30754;
+SET @HumanEarthTotem := 30753;
 SET @HumanWaterTotem := 30755;
 SET @HumanAirTotem := 30736;
 
-SET @NightElfFireTotem := 30753;
-SET @NightElfEarthTotem := 30754;
+SET @NightElfFireTotem := 30754;
+SET @NightElfEarthTotem := 30753;
 SET @NightElfWaterTotem := 30755;
 SET @NightElfAirTotem := 30736;
 
-SET @GnomeFireTotem := 30753;
-SET @GnomeEarthTotem := 30754;
+SET @GnomeFireTotem := 30754;
+SET @GnomeEarthTotem := 30753;
 SET @GnomeWaterTotem := 30755;
 SET @GnomeAirTotem := 30736;
 
 -- Horde default totems is the Orc ones.
-SET @UndeadFireTotem := 30757;
-SET @UndeadEarthTotem := 30758;
+SET @UndeadFireTotem := 30758;
+SET @UndeadEarthTotem := 30757;
 SET @UndeadWaterTotem := 30759;
 SET @UndeadAirTotem := 30756;
 
-SET @BloodElfFireTotem := 30757;
-SET @BloodElfEarthTotem := 30758;
+SET @BloodElfFireTotem := 30758;
+SET @BloodElfEarthTotem := 30757;
 SET @BloodElfWaterTotem := 30759;
 SET @BloodElfAirTotem := 30756;
 


### PR DESCRIPTION
THIS HAS NOT BE TESTED

I've ran the query and no issues.

By user's feedback prior to this I will assume this will fix it: https://discord.com/channels/217589275766685707/1396821204161134653/1397022908752334899

This changes applies to following races:
- Human  
- Night Elf  
- Undead  
- Gnome  
- Blood Elf  

Alliance totems will use the dwarf ones:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b0fce6b9-2a66-48aa-8358-a9e64fb59914" />

Horde totems will use the orc ones:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/544c5938-937b-4276-89c1-a318de31a913" />

--

I wanted to do the same for the shapeshift, but I'm unsure how it works for the haircolour and skincolour for night elf and tauren, even less the others. 

Unsure if this needs to be updated: https://github.com/TheSCREWEDSoftware/mod-arac/blob/update_player_totems_shapeshifts/data/sql/Copy%20for%20Custom%20Race.sql

