### PR TITLE
Corrected Build Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ![logo](https://raw.githubusercontent.com/azerothcore/azerothcore.github.io/master/images/logo-github.png) AzerothCore
 ## ARAC - All Races All Classes
 # ![ARAC icon](https://raw.githubusercontent.com/azerothcore/mod-arac/master/icon.png)
-- Latest build status with AzerothCore: [![Build Status](https://github.com/azerothcore/mod-arac/workflows/core-build/badge.svg?branch=master&event=push)](https://github.com/azerothcore/mod-arac)
+- Latest build status with AzerothCore: [![Build Status](https://github.com/azerothcore/mod-arac/actions/workflows/core-build.yml/badge.svg)](https://github.com/azerothcore/mod-arac/actions)
 
 ## Screenshot
 


### PR DESCRIPTION
Corrected the format of the action in readme and the workflow path name.

From:
<img width="733" height="68" alt="image" src="https://github.com/user-attachments/assets/5ebdc4ff-9dcb-4b7b-8b61-d287a618f6f7" />


To:
<img width="695" height="68" alt="image" src="https://github.com/user-attachments/assets/380e7b70-6ad3-47f0-91b5-617a259df386" />

Refering to faillign because of: https://github.com/heyitsbench/mod-arac/actions last one was a failture this should dynamiacally update depending on the build process
